### PR TITLE
Add ability to scale in any power of 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+
+[[package]]
 name = "waifu2x"
 version = "0.1.1"
 dependencies = [
@@ -140,4 +195,5 @@ dependencies = [
  "libc",
  "ncnn-sys",
  "path-absolutize",
+ "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ model_bundled = []
 [dependencies]
 libc = "0.2.139"
 ncnn-sys = "0.2.0"
+thiserror = "1.0.40"
 
 [dependencies.image]
 version = "0.24.5"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use quicli::prelude::*;
 use waifu2x::Waifu2x;
 
 fn main() -> CliResult {
-  let processer = Waifu2x::new(0, 0, 2, 128, true);
+  let processer = Waifu2x::new(0, 0, 2, 128, true)?;
   let image = open("image.png")?;
   processer.proc_image(image, false).save("output.png")?;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 mod waifu2x;
 
 pub use waifu2x::Waifu2x;
+pub use waifu2x::Waifu2xError;

--- a/src/waifu2x.rs
+++ b/src/waifu2x.rs
@@ -119,10 +119,7 @@ impl Waifu2x {
 
         let mut image = self.proc_image_iter(image);
 
-        if self.scale == 1 {
-            // run scaling once and resize back to original size
-            image = image.resize(width, height, CatmullRom);
-        } else {
+        if self.scale > 1 {
             for _ in 0..self.runs {
                 image = self.proc_image_iter(image);
             }

--- a/waifu2x/waifu2x.cpp
+++ b/waifu2x/waifu2x.cpp
@@ -463,8 +463,8 @@ extern "C" waifu2x * init_waifu2x(waifu2x_config * config, int gpuid)
 	return processer;
 }
 
-extern "C" int get_gpu_count(waifu2x * processer) {
-	return processer->gpu_count;
+extern "C" int get_gpu_count() {
+	return ncnn::get_gpu_count();
 }
 
 extern "C" void* proc_image(waifu2x_config * config, waifu2x * processer, unsigned char* data, int w, int h, int c, waifu2x_image * &image)


### PR DESCRIPTION
fixes #2 

- Added ability to scale in any power of 2
- Added sanity checks to `Waifu2x::new()` (it even checks for gpuid validity)
- Added support for image transparency, which solves the case for wrong output with images that had transparency

At this point, I wanted to keep the implementation simplified for now, so I kept it to a power of 2. Although with this base in place, it probably wouldn't be hard to make non-power of 2 scales work

the gpuid check actually prevents a segfault I was getting if an invalid gpuid gets entered. 

Let me know of any thoughts you have!